### PR TITLE
updated repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is an boilerplate repo to make it easy to experiment with [ES6]. It's inspi
 
 ```bash
 # Clone the repo...
-git clone https://github.com/thoughtram/es6-6to5-browserify-boilerplate.git
-cd es6-6to5-browserify-boilerplate
+git clone https://github.com/thoughtram/es6-babel-browserify-boilerplate.git
+cd es6-babel-browserify-boilerplate
 
 # Then, you need to install all the dependencies...
 npm install


### PR DESCRIPTION
It looks like the ReadMe `git` commands for cloning the repo were out of date (at least, not matching up to the es6-babel-browserify-boilerplate repo I'm staring at).
