### PR TITLE
Windows 10 error fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,10 @@ gulp.task('watch', ['build-persistent'], function() {
   });
 
   getBundler().on('update', function() {
-    gulp.start('build-persistent')
+    
+    //@mmaciejsikora - here change because was problem on windows with permissions
+    bundle();
+    
   });
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,6 @@ gulp.task('watch', ['build-persistent'], function() {
 
   getBundler().on('update', function() {
     
-    //@mmaciejsikora - here change because was problem on windows with permissions
     bundle();
     
   });


### PR DESCRIPTION
I had problems with gulp watching on windows 10 machine, i had  EPERM: operation not permitted, unlink error. Change to run bundle() instead of task helped and I can use watching on windows machine.